### PR TITLE
INTERLOK-3193 Added support for failed messages.

### DIFF
--- a/src/main/java/com/adaptris/profiler/MessageProcessStep.java
+++ b/src/main/java/com/adaptris/profiler/MessageProcessStep.java
@@ -31,6 +31,7 @@ public class MessageProcessStep implements ProcessStep, Serializable {
   private long timeStartedMs;
   private long timeTakenNanos;
   private long timeStartedNanos;
+  private boolean failed;
     
   @Override
   public void setTimeTakenMs(long time) {
@@ -141,5 +142,15 @@ public class MessageProcessStep implements ProcessStep, Serializable {
   @Override
   public void setTimeStartedNanos(long timeStarted) {
     this.timeStartedNanos = timeStarted;
+  }
+
+  @Override
+  public boolean isFailed() {
+    return failed;
+  }
+
+  @Override
+  public void setFailed(boolean failed) {
+    this.failed = failed;
   }
 }

--- a/src/main/java/com/adaptris/profiler/ProcessStep.java
+++ b/src/main/java/com/adaptris/profiler/ProcessStep.java
@@ -90,4 +90,14 @@ public interface ProcessStep {
   
   public void setTimeStartedNanos(long time);
   
+  /**
+   * Did this step produce an error?
+   * 
+   * @return true if the {@link AdaptrisMessage} is deemed to have failed this step.
+   */
+  public boolean isFailed();
+  
+  public void setFailed(boolean time);
+  
+  
 }

--- a/src/main/java/com/adaptris/profiler/aspects/WorkflowAspect.java
+++ b/src/main/java/com/adaptris/profiler/aspects/WorkflowAspect.java
@@ -27,6 +27,7 @@ import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 
 import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreConstants;
 import com.adaptris.core.Workflow;
 import com.adaptris.core.WorkflowImp;
 import com.adaptris.profiler.MessageProcessStep;
@@ -67,7 +68,10 @@ public class WorkflowAspect extends BaseAspect {
       // Step will only be null, if we've had an error in the beforeService
       if (step != null) {
         super.recordEventTimeTaken(step);
-
+        AdaptrisMessage message = (AdaptrisMessage) jp.getArgs()[1];
+        if(message.getObjectHeaders().containsKey(CoreConstants.OBJ_METADATA_EXCEPTION))
+          step.setFailed(true);
+        
         waitingForCompletion.remove(key);
         this.sendEvent(step);
         log("After Workflow", jp);


### PR DESCRIPTION
## Motivation

The profiler decides what metrics it will record from our components.  Currently they are mostly about capturing volumes and performance timings.  But now we would like to be able to see how many messages have failed.

## Modification

The serializable ProcessStep has been modified to add a new failed field, this is the object handed over to profiler plugins.  When a message after running through the workflow has an exception attached to it, then we know the message has failed and therefore set the failed flag.

## Result

Anyone creating a plug-in or using one of our existing plug-ins now have access to an isFailed() method.  Simply put these can now be tallied up for a count of failed messages.

