### PR TITLE
INTERLOK-3187 #comment Add repository and readme location to the pom …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -227,6 +227,8 @@ publishing {
         properties.appendNode("target", "3.8.0+")
         properties.appendNode("tags", "profiling")
         properties.appendNode("license", "false")
+        properties.appendNode("repository", "https://github.com/adaptris/interlok-profiler")		
+        properties.appendNode("readme", "https://raw.githubusercontent.com/adaptris/interlok-profiler/develop/README.md")		
       }
     }
   }


### PR DESCRIPTION
## Motivation

Give the UI the ability to point to the optional component repository

## Modification

Add two new properties into the pom file with the repository and the readme urls

## Result

The info will eventually be available in the UI(s)

## Testing

Check that the new repository property exist in the pom file after doing:
>gradle generatePomFileForMavenJavaPublication
