### PR TITLE
INTERLOK-3411 Update the producer cut points

### DIFF
--- a/src/main/java/com/adaptris/profiler/aspects/LoggingContextAspect.java
+++ b/src/main/java/com/adaptris/profiler/aspects/LoggingContextAspect.java
@@ -32,7 +32,8 @@ public class LoggingContextAspect {
   
   @Before("call(* com.adaptris.core.Service+.doService(com.adaptris.core.AdaptrisMessage)) "
       + "|| call(* com.adaptris.core.AdaptrisMessageListener+.onAdaptrisMessage(com.adaptris.core.AdaptrisMessage)) "
-      + "|| call(* com.adaptris.core.AdaptrisMessageListener+.onAdaptrisMessage(com.adaptris.core.AdaptrisMessage, java.util.function.Consumer))")
+      + "|| call(* com.adaptris.core.AdaptrisMessageListener+.onAdaptrisMessage(com.adaptris.core.AdaptrisMessage, java.util.function.Consumer)) "
+      + "|| call(* com.adaptris.core.AdaptrisMessageListener+.onAdaptrisMessage(com.adaptris.core.AdaptrisMessage, java.util.function.Consumer, java.util.function.Consumer))")
   public synchronized void beforeService(JoinPoint jp) {
     AdaptrisMessage msg = (AdaptrisMessage) jp.getArgs()[0];
     String msgId = msg.getUniqueId();


### PR DESCRIPTION
## Motivation

After deprecating **producer.produce(message, destination)** in favour of **producer.produce(message, string)** we need to update the profiler such that it can catch all invocations of the producer.

Additionally, we need to update the logging context aspect su that it can also listen for **onAdaptrisMessage(message, success, failure);**

## Modification

The producer aspect will now instrument all **producer.produce(message)** calls.  This seems to be the method called from the workflows, therefore it should catch all producers regardless if you're using the deprecated method or the replacement.

The only issue here though is that the profiler will also instrument event handlers.  So we now catch those inside the producer aspect.

## Result

Once users upgrade to the latest version of Interlok and update their producer config to not use the deprecated Destination this profiler will now instrument the new producer method.

## Testing

Enable the profiler preferably with the JMX monitor, run some messages through your adapter (making sure you use a producer with the new endpoint field instead of the destination) then you'll see logging every 5 seconds or so, which will include metrics for your new producer.
