### PR TITLE
INTERLOK-3414 Hook into request method

### DIFF
--- a/src/main/java/com/adaptris/profiler/aspects/ProducerAspect.java
+++ b/src/main/java/com/adaptris/profiler/aspects/ProducerAspect.java
@@ -36,7 +36,7 @@ public class ProducerAspect extends BaseAspect {
 
   private static Map<String, ProcessStep> waitingForCompletion = new HashMap<String, ProcessStep>();
 
-  @Before("call(void produce(com.adaptris.core.AdaptrisMessage)) && within(com.adaptris..*)")
+  @Before("(call(void produce(com.adaptris.core.AdaptrisMessage)) || call(com.adaptris.core.AdaptrisMessage request(com.adaptris.core.AdaptrisMessage))) && within(com.adaptris..*)")
   public synchronized void beforeService(JoinPoint jp) {
     try {
       AdaptrisMessage message = (AdaptrisMessage) jp.getArgs()[0];
@@ -54,7 +54,7 @@ public class ProducerAspect extends BaseAspect {
     }
   }
 
-  @After("call(void produce(com.adaptris.core.AdaptrisMessage)) && within(com.adaptris..*)")
+  @After("(call(void produce(com.adaptris.core.AdaptrisMessage)) || call(com.adaptris.core.AdaptrisMessage request(com.adaptris.core.AdaptrisMessage))) && within(com.adaptris..*)")
   public synchronized void afterService(JoinPoint jp) {
     AdaptrisMessage message = (AdaptrisMessage) jp.getArgs()[0];
     if (message.getMetadataValue(CoreConstants.EVENT_CLASS) == null) { // only for non-event produced messages.


### PR DESCRIPTION
As well as monitoring produce(), also monitor request().

## Motivation

As well as the ```produce()``` method, this will now allow profiling of the ```request()``` method.

## Modification

Update the ```@Before``` and ```@After``` annotations to include the ```request()``` method.

## Result

Whoever is using the profiler should now be able to see how long the ```request()``` methods takes.

## Testing

Use the profiler.
