### PR TITLE
INTERLOK-3764

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,6 @@
+import org.apache.tools.ant.taskdefs.condition.Os
+import org.apache.tools.ant.filters.*
+
 plugins {
   id 'java'
   id 'maven'
@@ -6,7 +9,9 @@ plugins {
   // Manage optional dependencies in maven pom.
   id 'nebula.optional-base' version '6.0.0'
   id 'com.github.spotbugs' version '4.7.1'
+  id "io.freefair.lombok" version "5.3.3.3"
   id 'org.owasp.dependencycheck' version '6.1.6'
+
 }
 
 ext {
@@ -22,12 +27,17 @@ ext {
 
   interlokJavadocs= project.hasProperty('interlokJavadocs') ? project.getProperty('interlokJavadocs') : javadocsBaseUrl + "/interlok-core/" + interlokCoreVersion
   interlokCommonJavadocs= project.hasProperty('interlokCommonJavadocs') ? project.getProperty('interlokCommonJavadocs') : javadocsBaseUrl + "/interlok-common/" + interlokCoreVersion
-  componentName='Interlok Profiling/Core'
-  componentDesc="Instrument Interlok to provide profiling data during runtime."
+
+  delombokTargetDir = new File("${project.projectDir}/src/main/generated")
+
+  componentName='Interlok Profiler'
+  componentDesc="Perform instrumentation to profile Interlok runtime."
 
   organizationName = "Adaptris Ltd"
   organizationUrl = "http://interlok.adaptris.net"
   slf4jVersion = '1.7.30'
+  tikaVersion = "1.26"
+  mockitoVersion = '3.9.0'
   aspectjVersion = '1.9.6'
 }
 
@@ -38,6 +48,7 @@ if (JavaVersion.current().isJava8Compatible()) {
     }
   }
 }
+
 ext.gitBranchNameOrTimestamp = { branchName ->
   if (branchName.equals("HEAD") || branchName.equals("develop") || branchName.startsWith("release")) {
     return new Date().format('HH:mm:ss z');
@@ -62,21 +73,16 @@ targetCompatibility = JavaVersion.VERSION_11
 group   = 'com.adaptris'
 version = releaseVersion
 def versionDir = "$buildDir/version"
+generateLombokConfig.enabled = false
 
 // In this section you declare where to find the dependencies of your project
 repositories {
   mavenCentral()
   maven { url "$defaultNexusRepo" }
-  maven {
-      credentials {
-        username repoUsername
-        password repoPassword
-      }
-      url "$nexusBaseUrl/content/groups/private"
-    }
   maven { url "$nexusBaseUrl/content/groups/public" }
   maven { url "$nexusBaseUrl/content/groups/interlok" }
 }
+
 
 configurations {
   javadoc {}
@@ -88,7 +94,8 @@ configurations {
   all*.exclude group: 'org.glassfish.hk2.external'
   all*.exclude group: 'xalan', module: 'xalan'
   all*.exclude group: 'net.sf.saxon', module: 'saxon'
-  all*.exclude group: 'org.codehaus.woodstox'
+  // don't exclude woodstox; as tika-parsers -> org.apache.cxf:cxf-rt-rs-client -> com.fasterxml.woodstox:woodstox-core
+  // all*.exclude group: 'org.codehaus.woodstox'
   all*.exclude group: 'org.eclipse.jetty.orbit', module: 'javax.mail.glassfish'
   // INTERLOK-3197 exclude old javax.mail
   all*.exclude group: 'com.sun.mail', module: 'javax.mail'
@@ -145,6 +152,7 @@ jar {
   }
 }
 
+
 sourceSets {
   main {
     output.dir(versionDir, builtBy: 'generateVersion')
@@ -160,7 +168,7 @@ task generateVersion {
       entry(key: 'component.description', value: componentDesc)
       entry(key: 'groupId', value: project.group)
       entry(key: 'artifactId', value: project.name)
-      entry(key: 'build.version', value: project.version)
+      entry(key: 'build.version', value: releaseVersion)
       entry(key: 'build.date', value: new Date().format('yyyy-MM-dd'))
       entry(key: 'build.info', value: buildInfo())
     }
@@ -181,7 +189,6 @@ task offlinePackageList(type: Copy) {
   into offlineJavadocPackageDir
 }
 
-
 javadoc {
   configure(options) {
     options.linksOffline(interlokJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-core-$interlokCoreVersion-javadoc.jar")
@@ -200,6 +207,23 @@ jacocoTestReport {
     }
 }
 
+task deleteGeneratedFiles(type: Delete) {
+  delete delombokTargetDir
+}
+
+delombok {
+  target = delombokTargetDir
+}
+
+task lgtmCompile(type: JavaCompile, dependsOn: delombok) {
+  group 'Build'
+  description 'Compile for lgtm'
+
+  source = sourceSets.main.extensions.delombokTask
+  destinationDir = sourceSets.main.java.outputDir
+  classpath = project.sourceSets.main.compileClasspath
+}
+
 task javadocJar(type: Jar, dependsOn: javadoc) {
   classifier = 'javadoc'
   from javadoc.destinationDir
@@ -212,8 +236,9 @@ task examplesJar(type: Jar, dependsOn: test) {
 
 task sourcesJar(type: Jar, dependsOn: classes) {
     classifier = 'sources'
-    from sourceSets.main.allSource
+    from sourceSets.main.extensions.delombokTask
 }
+
 artifacts {
   archives javadocJar
   archives examplesJar
@@ -230,14 +255,13 @@ publishing {
       artifact sourcesJar { classifier "sources" }
 
       pom.withXml {
-        asNode().appendNode("description", componentDesc)
         asNode().appendNode("name", componentName)
+        asNode().appendNode("description", componentDesc)
         def properties = asNode().appendNode("properties")
-        properties.appendNode("target", "3.8.0+")
-        properties.appendNode("tags", "profiling")
+        properties.appendNode("target", "3.1+")
+        properties.appendNode("tags", "profiler")
         properties.appendNode("license", "false")
         properties.appendNode("repository", "https://github.com/adaptris/interlok-profiler")
-        properties.appendNode("readme", "https://github.com/adaptris/interlok-profiler/raw/develop/README.md")
       }
     }
   }
@@ -272,7 +296,7 @@ spotbugsMain {
 }
 
 dependencyCheck  {
-  suppressionFiles= [ "https://raw.githubusercontent.com/adaptris/interlok/develop/gradle/owasp-exclude.xml" ]
+  suppressionFiles= [ "https://raw.githubusercontent.com/adaptris/interlok/develop/gradle/owasp-exclude.xml" , "$rootDir/gradle/owasp-exclude.xml" ]
   skipConfigurations = [ "antSql", "spotbugs", "umlDoclet", "offlineJavadocPackages", "javadoc", "jacocoAnt", "jacocoAgent", "spotbugsPlugins", "spotbugsSlf4j" ]
   formats = [ "HTML", "JUNIT" ]
   junitFailOnCVSS = 7.0
@@ -284,7 +308,6 @@ dependencyCheck  {
 
 // disable spotbugsTests which checks our test code..
 spotbugsTest.enabled = false
-
-
+clean.dependsOn deleteGeneratedFiles
 check.dependsOn jacocoTestReport
 javadoc.dependsOn offlinePackageList

--- a/src/main/java/com/adaptris/profiler/MessageProcessStep.java
+++ b/src/main/java/com/adaptris/profiler/MessageProcessStep.java
@@ -18,75 +18,46 @@ package com.adaptris.profiler;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+
 public class MessageProcessStep implements ProcessStep, Serializable {
 
   private static final long serialVersionUID = 201310141247L;
 
+  @Getter
+  @Setter
   private String messageId;
+  @Getter
+  @Setter
   private String stepName;
+  @Getter
+  @Setter
   private String stepInstanceId;
+  @Getter
+  @Setter
+  private String workflowId;
+  @Getter
+  @Setter
   private StepType stepType;
+  @Getter
+  @Setter
   private long order;
+  @Getter
+  @Setter
   private long timeTakenMs;
+  @Getter
+  @Setter
   private long timeStartedMs;
+  @Getter
+  @Setter
   private long timeTakenNanos;
+  @Getter
+  @Setter
   private long timeStartedNanos;
+  @Getter
+  @Setter
   private boolean failed;
-    
-  @Override
-  public void setTimeTakenMs(long time) {
-    this.timeTakenMs = time;
-  }
-  
-  @Override
-  public long getTimeTakenMs() {
-    return timeTakenMs;
-  }
-  
-  @Override
-  public String getStepName() {
-    return stepName;
-  }
-
-  @Override
-  public String getStepInstanceId() {
-    return stepInstanceId;
-  }
-
-  @Override
-  public String getMessageId() {
-    return messageId;
-  }
-
-  public void setMessageId(String messageId) {
-    this.messageId = messageId;
-  }
-
-  public void setStepName(String stepName) {
-    this.stepName = stepName;
-  }
-
-  public void setStepInstanceId(String stepInstanceId) {
-    this.stepInstanceId = stepInstanceId;
-  }
-
-  @Override
-  public StepType getStepType() {
-    return stepType;
-  }
-
-  public void setStepType(StepType stepType) {
-    this.stepType = stepType;
-  }
-
-  @Override
-  public long getOrder() {
-    return order;
-  }
-
-  public void setOrder(long order) {
-    this.order = order;
-  }
 
   @Override
   public boolean equals(Object object) {
@@ -114,43 +85,4 @@ public class MessageProcessStep implements ProcessStep, Serializable {
     return buffer.toString();
   }
 
-  @Override
-  public long getTimeStarted() {
-    return timeStartedMs;
-  }
-  
-  @Override
-  public void setTimeStarted(long timeStarted) {
-    this.timeStartedMs = timeStarted;
-  }
-
-  @Override
-  public long getTimeTakenNanos() {
-    return this.timeTakenNanos;
-  }
-
-  @Override
-  public void setTimeTakenNanos(long time) {
-    this.timeTakenNanos = time;
-  }
-
-  @Override
-  public long getTimeStartedNanos() {
-    return this.timeStartedNanos;
-  }
-  
-  @Override
-  public void setTimeStartedNanos(long timeStarted) {
-    this.timeStartedNanos = timeStarted;
-  }
-
-  @Override
-  public boolean isFailed() {
-    return failed;
-  }
-
-  @Override
-  public void setFailed(boolean failed) {
-    this.failed = failed;
-  }
 }

--- a/src/main/java/com/adaptris/profiler/ProcessStep.java
+++ b/src/main/java/com/adaptris/profiler/ProcessStep.java
@@ -26,6 +26,13 @@ public interface ProcessStep {
   public String getStepName();
   
   /**
+   * Get the name of the step which is generally the classname of the component.
+   * 
+   * @return the step name.
+   */
+  public String getWorkflowId();
+  
+  /**
    * Get the id of the step instance.
    * 
    * @return the instance id; generally the unique id of the component.
@@ -77,9 +84,9 @@ public interface ProcessStep {
    * 
    * @return when the process step was started; represented by {@link System#currentTimeMillis()}
    */
-  public long getTimeStarted();
+  public long getTimeStartedMs();
   
-  public void setTimeStarted(long time);
+  public void setTimeStartedMs(long time);
   
   /**
    * Get when the process step was started.

--- a/src/main/java/com/adaptris/profiler/ProcessStep.java
+++ b/src/main/java/com/adaptris/profiler/ProcessStep.java
@@ -26,9 +26,9 @@ public interface ProcessStep {
   public String getStepName();
   
   /**
-   * Get the name of the step which is generally the classname of the component.
+   * Get the unique-id of the parent workflow.
    * 
-   * @return the step name.
+   * @return the workflow id.
    */
   public String getWorkflowId();
   

--- a/src/main/java/com/adaptris/profiler/aspects/BaseAspect.java
+++ b/src/main/java/com/adaptris/profiler/aspects/BaseAspect.java
@@ -31,6 +31,8 @@ import com.adaptris.profiler.jmx.EventReceiverToJMX;
 
 abstract class BaseAspect {
 
+  protected static final String WORKFLOW_ID_KEY = "AdaptrisWorkflowEntryID";
+  
   private static final ExecutorService threadPool = Executors.newCachedThreadPool();
   private StepIncrementor sequenceGenerator = new MessageStepIncrementor();
   protected transient Logger log = LoggerFactory.getLogger(this.getClass());
@@ -53,13 +55,14 @@ abstract class BaseAspect {
     return sequenceGenerator.generate(msgId);
   }
 
-  protected MessageProcessStep createStep(StepType type, Object o, String messageId) {
+  protected MessageProcessStep createStep(StepType type, Object o, String messageId, String workflowId) {
     MessageProcessStep step = new MessageProcessStep();
     step.setMessageId(messageId);
     step.setStepType(type);
     step.setOrder(getNextSequenceNumber(messageId));
     step.setStepName(o.getClass().getSimpleName());
     step.setStepInstanceId(ReflectionHelper.getUniqueId(o));
+    step.setWorkflowId(workflowId);
     return step;
   }
 
@@ -76,12 +79,12 @@ abstract class BaseAspect {
   }
   
   protected void recordEventStartTime(ProcessStep processStep) {
-    processStep.setTimeStarted(System.currentTimeMillis());
+    processStep.setTimeStartedMs(System.currentTimeMillis());
     processStep.setTimeStartedNanos(System.nanoTime());
   }
   
   protected void recordEventTimeTaken(ProcessStep processStep) {
-    long differenceMs = System.currentTimeMillis() - processStep.getTimeStarted();
+    long differenceMs = System.currentTimeMillis() - processStep.getTimeStartedMs();
     processStep.setTimeTakenMs(differenceMs);
     long differenceNanos = System.nanoTime() - processStep.getTimeStartedNanos();
     processStep.setTimeTakenNanos(differenceNanos);

--- a/src/main/java/com/adaptris/profiler/aspects/ProducerAspect.java
+++ b/src/main/java/com/adaptris/profiler/aspects/ProducerAspect.java
@@ -42,7 +42,7 @@ public class ProducerAspect extends BaseAspect {
       AdaptrisMessage message = (AdaptrisMessage) jp.getArgs()[0];
       if (message.getMetadataValue(CoreConstants.EVENT_CLASS) == null) { // only for non-event produced messages.
         if (ReflectionHelper.getUniqueId(jp.getTarget()) != null) { // won't deal with producers that have no unique-id.
-          MessageProcessStep step = createStep(StepType.PRODUCER, jp.getTarget(), message.getUniqueId());
+          MessageProcessStep step = createStep(StepType.PRODUCER, jp.getTarget(), message.getUniqueId(), message.getMetadataValue(WORKFLOW_ID_KEY));
           super.recordEventStartTime(step);
 
           waitingForCompletion.put(generateStepKey(jp), step);

--- a/src/main/java/com/adaptris/profiler/aspects/ServiceAspect.java
+++ b/src/main/java/com/adaptris/profiler/aspects/ServiceAspect.java
@@ -39,7 +39,7 @@ public class ServiceAspect extends BaseAspect {
     try {
       AdaptrisMessage message = (AdaptrisMessage) jp.getArgs()[0];
 
-      MessageProcessStep step = createStep(StepType.SERVICE, jp.getTarget(), message.getUniqueId());
+      MessageProcessStep step = createStep(StepType.SERVICE, jp.getTarget(), message.getUniqueId(), message.getMetadataValue(WORKFLOW_ID_KEY));
       super.recordEventStartTime(step);
       
       waitingForCompletion.put(generateStepKey(jp), step);

--- a/src/main/java/com/adaptris/profiler/jmx/EventReceiverToJMX.java
+++ b/src/main/java/com/adaptris/profiler/jmx/EventReceiverToJMX.java
@@ -45,13 +45,14 @@ public class EventReceiverToJMX implements EventReceiver {
 
   private TimedThroughputMetricMBean getOrCreateMBean(ProcessStep processStep) throws Exception {
     TimedThroughputMetricMBean metricMbean = null;
-    metricMbean = beanCache.get(processStep.getStepInstanceId());
+    metricMbean = beanCache.get(processStep.getWorkflowId() + ":" + processStep.getStepInstanceId());
     
     if(metricMbean == null) {
       metricMbean = new TimedThroughputMetric();
       metricMbean.setUniqueId(processStep.getStepInstanceId());
+      metricMbean.setWorkflowId(processStep.getWorkflowId());
       
-      beanCache.put(processStep.getStepInstanceId(), metricMbean);
+      beanCache.put(processStep.getWorkflowId() + ":" + processStep.getStepInstanceId(), metricMbean);
       
       JmxHelper.register(
           new ObjectName(JMX_OBJECT_NAME.replace("$1", processStep.getStepType().name().toLowerCase()).replace("$2", processStep.getStepInstanceId())), 

--- a/src/main/java/com/adaptris/profiler/jmx/TimedThroughputMetric.java
+++ b/src/main/java/com/adaptris/profiler/jmx/TimedThroughputMetric.java
@@ -2,37 +2,28 @@ package com.adaptris.profiler.jmx;
 
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
 
+import lombok.Getter;
+import lombok.Setter;
+
 public class TimedThroughputMetric implements TimedThroughputMetricMBean {
 
+  @Getter
+  @Setter
   private String uniqueId;
   
+  @Getter
+  @Setter
+  private String workflowId;
+
+  @Getter
+  @Setter
   private long messageCount, failedMessageCount;
   
   private DescriptiveStatistics averageNanos = new DescriptiveStatistics(100);
 
   @Override
-  public String getUniqueId() {
-    return uniqueId;
-  }
-
-  @Override
-  public void setUniqueId(String uniqueId) {
-    this.uniqueId = uniqueId;
-  }
-
-  @Override
-  public long getMessageCount() {
-    return messageCount;
-  }
-
-  @Override
   public void addToMessageCount() {
     messageCount ++;
-  }
-
-  @Override
-  public long getFailedMessageCount() {
-    return failedMessageCount;
   }
 
   @Override
@@ -41,13 +32,12 @@ public class TimedThroughputMetric implements TimedThroughputMetricMBean {
   }
 
   @Override
-  public long getAverageNanoseconds() {
-    return Double.valueOf(averageNanos.getMean()).longValue();
-  }
-
-  @Override
   public void addToAverageNanoseconds(long nanoseconds) {
     averageNanos.addValue(nanoseconds);
   }
 
+  @Override
+  public long getAverageNanoseconds() {
+    return Double.valueOf(averageNanos.getMean()).longValue();
+  }
 }

--- a/src/main/java/com/adaptris/profiler/jmx/TimedThroughputMetricMBean.java
+++ b/src/main/java/com/adaptris/profiler/jmx/TimedThroughputMetricMBean.java
@@ -4,6 +4,10 @@ public interface TimedThroughputMetricMBean {
   
   public String getUniqueId();
   
+  public void setWorkflowId(String workflowId);
+  
+  public String getWorkflowId();
+  
   public void setUniqueId(String uniqueId);
 
   public long getMessageCount();
@@ -17,4 +21,5 @@ public interface TimedThroughputMetricMBean {
   public long getAverageNanoseconds();
   
   public void addToAverageNanoseconds(long nanoseconds);
+  
 }


### PR DESCRIPTION
## Motivation

Lombok all the things.

Presently it's not possible to determine the workflow for any service or producer.  This means you can't create a metrics chart of the processing times for just one workflow.  It makes the metrics for services and producers less useful.
The main reason for this PR is to enable our metric gatherers to tag each metric with the Workflow ID.

## Modification

The gradle.build has been updated to allow Lombok; which inevitably mean a few class files have also changed.

The main changes however are the workflow aspect now records the unique-id of itself in the message as metadata.
This allows the service/producer aspects to recall the workflow ID and add that to the profiling ProcessStep.

Next we have the JMX profiling event handler which can now update the MBeans with the workflow ID for each component.
Essentially all of these changes simply mean the TimedThroughputMetricMBean now has a getWorkflowId/setWorkflowId.

## PR Checklist

- [x] been self-reviewed.
- [ ] Added javadocs for most classes and all non-trivial methods
- [x] Checked that new 3rd party dependencies are appropriately licensed
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader

## Result

Each metric published to whatever provider you choose now has the workflow ID tagged to it, allowing you to create awesome graphs and charts which might include only the services/producers for a particular workflow.

## Testing

Run the profiler making sure you've had some activity running through your workflows, then simply open JConsole and check the profiler MBeans; each MBean that represents a component in one of your workflows will have a WorkflowID.
